### PR TITLE
fix: regex with 1 or more days digits

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -2,7 +2,7 @@ const body = document.body;
 
 const scheduleRegex = /^https:\/\/ais.usvisa-info.com\/.*\/niv\/schedule\/(\d+).*$/;
 const appointmentPageRegex = /^https:\/\/ais.usvisa-info.com\/.*\/niv\/schedule\/\d+\/appointment$/;
-const appointmentJsonRegex = /^https:\/\/ais.usvisa-info.com\/.*\/niv\/schedule\/\d+\/appointment\/days\/\d\d\.json\?appointments\[expedite\]\=false$/;
+const appointmentJsonRegex = /^https:\/\/ais.usvisa-info.com\/.*\/niv\/schedule\/\d+\/appointment\/days\/\d+\.json\?appointments\[expedite\]\=false$/;
 
 function sleep(n) {
   return new Promise(r => setTimeout(r, n));


### PR DESCRIPTION
Match 1 or more digits for the days pathVariable in JSON regex.

### TL;DR

Na página mostrando o JSON com as datas disponíveis, notei que o script não estava sendo executado conforme esperado. Com o objetivo de enteder melhor o código, e durante o processo de debug, identifiquei que o meu link possuía, na verdade, três digitos no path variable de **days**. Porém, no código, eram esperados apenas dois digitos.

Eu acredito que este ID seja correspondente ao ID do consulado. Para a seção de Porto Alegre, o ID é `128`, causando então com que o RegEx não seja correspondente. Todos as demais seções parecem mesmo ter apenas dois digitos.

Como correção, este PR propõe alterar o `appointmentJsonRegex` para considerar o days como `\d+` ao invés de `/d/d`.

